### PR TITLE
Small changes to Item styling

### DIFF
--- a/src/components/builderPage/builderPage.css
+++ b/src/components/builderPage/builderPage.css
@@ -117,6 +117,10 @@
                     &.react-draggable-dragging {
                         box-shadow: 0 5px 15px gray;
                     }
+
+                    &.react-grid-placeholder {
+                        background-color: #CCC
+                    }
                 }
             }
         }

--- a/src/components/builderPage/builderPage.css
+++ b/src/components/builderPage/builderPage.css
@@ -83,8 +83,20 @@
                         position: absolute;
                         top: 0;
                         right: 0;
+                        visibility: hidden;
                     }
 
+                    .react-resizable-handle {
+                        visibility: hidden;
+                    }
+
+
+
+                    &:is(:hover, :focus, :focus-within) {
+                        border: 1px dotted gray;
+                        .deleteItem, .react-resizable-handle {
+                            visibility: visible;
+                        }
                     }
 
                     input[type="text"] {

--- a/src/components/builderPage/builderPage.css
+++ b/src/components/builderPage/builderPage.css
@@ -112,6 +112,10 @@
                         resize: none;
                         width: 100% !important;
                         height: 100% !important;
+                        border: none;
+                    }
+                    &.react-draggable-dragging {
+                        box-shadow: 0 5px 15px gray;
                     }
                 }
             }

--- a/src/components/builderPage/builderPage.css
+++ b/src/components/builderPage/builderPage.css
@@ -71,9 +71,8 @@
                     position: relative;
                     display: grid;
                     place-items: center;
-                    border: 1px solid;
-                    border-radius: 2px;
                     background-color: white;
+                    box-sizing: border-box;
 
                     .deleteItem {
                         background: unset;
@@ -84,11 +83,8 @@
                         position: absolute;
                         top: 0;
                         right: 0;
-                        opacity: 0;
                     }
 
-                    &:is(:hover, :focus, :focus-within) .deleteItem {
-                        opacity: 1;
                     }
 
                     input[type="text"] {


### PR DESCRIPTION
This PR shows how you can make some small changes to the builder which I think make it a little easier on the eyes.  It removes the border around items unless they are hovered, so that you can see how your page looks without the extra clutter.

It also adds a box shadow when an item is being moved.

EDIT

I'm going to add a placeholder effect in a minute.