### PR TITLE
Add EmptySpace component

### DIFF
--- a/src/components/builderPage/builderPage.css
+++ b/src/components/builderPage/builderPage.css
@@ -19,23 +19,33 @@
                 overflow: auto;
 
                 .item {
+                    position: relative;
                     border-bottom: 2px solid grey;
                     padding-bottom: 5px;
                     max-height: 100px;
                     padding-block: 10px;
                     height: 100px;
-                    display: grid;
-                    grid-template-columns: 1fr 55px;
+                    display: flex;
                     align-items: center;
                     gap: 15px;
 
-                    textarea {
-                        height: 90%;
+                    .component {
+                        border: 1px dotted gray;
+                        border-radius: 5px;
+                        position: relative;
+                        height: 100%;
+                        flex: 1 1 auto;
+                        textarea {
+                            width: 100%;
+                        }
+                        .addItem {
+                            flex: 1 0 auto;
+                        }
                     }
 
-                    .addItem {
-                        padding: 5px 10px;
-                    }
+                    
+
+                    
                 }
             }
 

--- a/src/components/builderPage/builderPage.jsx
+++ b/src/components/builderPage/builderPage.jsx
@@ -10,6 +10,7 @@ import "../../../node_modules/react-resizable/css/styles.css";
 import LabelInput from "../draggables/labelInput";
 import Textarea from "../draggables/textarea";
 import StatInput from "../draggables/statInput";
+import EmptySpace from "../draggables/emptySpace";
 
 //OTHER COMPONENTS
 import Nav from "../nav/navBar";
@@ -28,6 +29,11 @@ const buildingBlocks = [
     },
     {
         name: "StatInput",
+        width: 2,
+        height: 2
+    },
+    {
+        name: "EmptySpace",
         width: 2,
         height: 2
     }
@@ -106,7 +112,8 @@ class Builder extends Component {
         const components = {
             LabelInput: <LabelInput key={key}/>,
             Textarea: <Textarea key={key}/>,
-            StatInput: <StatInput key={key}/>
+            StatInput: <StatInput key={key}/>,
+            EmptySpace: <EmptySpace key={key}/>
         };
         
         return components[name] || null;

--- a/src/components/builderPage/builderPage.jsx
+++ b/src/components/builderPage/builderPage.jsx
@@ -124,7 +124,9 @@ class Builder extends Component {
             <div className="picker">
                 {buildingBlocks.map((block, index) => {
                         return <div className="item" key={index}>
-                            {this.renderComponent(block.name, index)}
+                            <div className="component">
+                                {this.renderComponent(block.name, index)}
+                            </div>
                             <button
                             className="addItem"
                             onClick={() => this.addNewItem(block.name, block.width, block.height)}

--- a/src/components/draggables/emptySpace.jsx
+++ b/src/components/draggables/emptySpace.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const EmptySpace = () => {
+  return (
+      <div class='empty-space'>
+      </div>
+  );
+};
+
+export default EmptySpace;


### PR DESCRIPTION
With React Draggable, it's not possible to add blank vertical space between items- everything just shifts up.  This PR adds a "EmptySpace" component that can be dropped in to take up some space.

It also does a small change to the structure of the component list, adding another div wrapper so that a border can be added to the component.  This is important for the Empty Space component, since otherwise there is nothing to display, but I think it improves other components as well.

<img width="820" alt="image" src="https://github.com/5e-Cleric/charactersheetbuilder/assets/58999374/b0b21bab-5ac8-4696-8525-176ae867ece2">
